### PR TITLE
feat: ui responsiveness

### DIFF
--- a/lib/feature/area/area_page.dart
+++ b/lib/feature/area/area_page.dart
@@ -63,9 +63,10 @@ class _AreaPageState extends ConsumerState<AreaPage> {
       body: const VerticalSpace(space: 40.0),
       isBackButtonShown: true,
       cardRadius: areaPageCardRadius,
-      cardBody: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      cardBody: ListView(
+        padding: EdgeInsets.zero,
         children: [
+          const VerticalSpace(space: 32.0),
           Padding(
             padding: EdgeInsets.only(
               left: selectedCategory != ParkingCategory.halls ? 0 : areaPagePadding,
@@ -105,6 +106,7 @@ class _AreaPageState extends ConsumerState<AreaPage> {
               ],
             ),
           ),
+          const VerticalSpace(space: 16.0),
           FlutterCarousel.builder(
             itemCount: areaCount,
             itemBuilder: (_, index, __) => AreaCard(
@@ -121,26 +123,32 @@ class _AreaPageState extends ConsumerState<AreaPage> {
               onPageChanged: (index, _) => _currentIndexNotifier.value = index,
             ),
           ),
-          SizedBox(
-            width: carouselIndicatorWidth,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: List.generate(
-                areaCount,
-                (index) => ValueListenableBuilder<int>(
-                  valueListenable: _currentIndexNotifier,
-                  builder: (_, currentIndex, __) => CircleAvatar(
-                    radius: carouselIndicatorRadius,
-                    backgroundColor: currentIndex == index ? activeIndicatorColor : inactiveIndicatorColor,
+          const VerticalSpace(space: 64.0),
+          Center(
+            child: SizedBox(
+              width: carouselIndicatorWidth,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(
+                  areaCount,
+                  (index) => ValueListenableBuilder<int>(
+                    valueListenable: _currentIndexNotifier,
+                    builder: (_, currentIndex, __) => CircleAvatar(
+                      radius: carouselIndicatorRadius,
+                      backgroundColor: currentIndex == index ? activeIndicatorColor : inactiveIndicatorColor,
+                    ),
                   ),
                 ),
               ),
             ),
           ),
+          const VerticalSpace(space: 64.0),
           Text(
             swipeToSelectLabel,
+            textAlign: TextAlign.center,
             style: TextStyles.medium.copyWith(color: color),
           ),
+          const VerticalSpace(space: 16.0),
         ],
       ),
     );

--- a/lib/feature/area/area_page.dart
+++ b/lib/feature/area/area_page.dart
@@ -57,6 +57,8 @@ class _AreaPageState extends ConsumerState<AreaPage> {
     final areaCount = areas.length;
     final imageUrl = selectedCategory.imageUrl;
     final color = context.isDarkMode ? Colors.white : Colors.black;
+    const verticalSpaceLarge = VerticalSpace(space: 64.0);
+    const verticalSpaceSmall = VerticalSpace(space: 16.0);
 
     return ParmosysScaffold(
       header: areaPageHeaders,
@@ -106,7 +108,7 @@ class _AreaPageState extends ConsumerState<AreaPage> {
               ],
             ),
           ),
-          const VerticalSpace(space: 16.0),
+          verticalSpaceSmall,
           FlutterCarousel.builder(
             itemCount: areaCount,
             itemBuilder: (_, index, __) => AreaCard(
@@ -123,7 +125,7 @@ class _AreaPageState extends ConsumerState<AreaPage> {
               onPageChanged: (index, _) => _currentIndexNotifier.value = index,
             ),
           ),
-          const VerticalSpace(space: 64.0),
+          verticalSpaceLarge,
           Center(
             child: SizedBox(
               width: carouselIndicatorWidth,
@@ -142,13 +144,13 @@ class _AreaPageState extends ConsumerState<AreaPage> {
               ),
             ),
           ),
-          const VerticalSpace(space: 64.0),
+          verticalSpaceLarge,
           Text(
             swipeToSelectLabel,
             textAlign: TextAlign.center,
             style: TextStyles.medium.copyWith(color: color),
           ),
-          const VerticalSpace(space: 16.0),
+          verticalSpaceSmall,
         ],
       ),
     );

--- a/lib/feature/category/category_button.dart
+++ b/lib/feature/category/category_button.dart
@@ -27,49 +27,52 @@ class CategoryButton extends StatelessWidget {
     final isDarkMode = context.isDarkMode;
     final imageUrl = parkingCategory.imageUrl;
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        SizedBox(
-          height: categoryButtonHeight,
-          width: categoryButtonWidth,
-          child: InkWell(
-            onTap: () => onTap(parkingCategory),
-            borderRadius: borderRadius,
-            splashColor: lightBackgroundColor,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Container(
-                  height: categoryButtonBackgroundHeight,
-                  width: categoryButtonBackgroundWidth,
-                  decoration: BoxDecoration(
-                    color: isDarkMode ? cardButtonDarkColor : cardButtonLightColor,
-                    borderRadius: borderRadius,
-                  ),
-                ),
-                Positioned(
-                  top: imageTopPosition,
-                  left: imageLeftPosition,
-                  child: Hero(
-                    tag: imageUrl,
-                    child: Image.asset(
-                      imageUrl,
-                      width: imageSize,
-                      height: imageSize,
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            height: categoryButtonHeight,
+            width: categoryButtonWidth,
+            child: InkWell(
+              onTap: () => onTap(parkingCategory),
+              borderRadius: borderRadius,
+              splashColor: lightBackgroundColor,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    height: categoryButtonBackgroundHeight,
+                    width: categoryButtonBackgroundWidth,
+                    decoration: BoxDecoration(
+                      color: isDarkMode ? cardButtonDarkColor : cardButtonLightColor,
+                      borderRadius: borderRadius,
                     ),
                   ),
-                ),
-              ],
+                  Positioned(
+                    top: imageTopPosition,
+                    left: imageLeftPosition,
+                    child: Hero(
+                      tag: imageUrl,
+                      child: Image.asset(
+                        imageUrl,
+                        width: imageSize,
+                        height: imageSize,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-        const VerticalSpace(space: 8.0),
-        Text(
-          parkingCategory.header,
-          style: TextStyles.bold.copyWith(color: isDarkMode ? Colors.white : cardButtonLightColor),
-        )
-      ],
+          const VerticalSpace(space: 8.0),
+          Text(
+            parkingCategory.header,
+            style: TextStyles.bold.copyWith(color: isDarkMode ? Colors.white : cardButtonLightColor),
+            overflow: TextOverflow.ellipsis,
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/category/category_page.dart
+++ b/lib/feature/category/category_page.dart
@@ -24,12 +24,13 @@ class CategoryPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ParmosysScaffold(
       header: categoryPageHeader,
-      body: Container(
-        padding: lancerSideImagePadding,
-        alignment: Alignment.centerRight,
-        child: Image.asset(
-          Assets.png.lancerSide.path,
-          scale: lancerSideImageScale,
+      body: Expanded(
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: Image.asset(
+            Assets.png.lancerSide.path,
+            width: MediaQuery.of(context).size.width * lancerSideImageMultiplier,
+          ),
         ),
       ),
       cardBody: Row(

--- a/lib/feature/home.dart
+++ b/lib/feature/home.dart
@@ -1,3 +1,4 @@
+import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parmosys_flutter/providers/selected_theme_provider.dart';
@@ -27,6 +28,8 @@ class _HomeState extends ConsumerState<Home> {
       routeInformationParser: router.routeInformationParser,
       routeInformationProvider: router.routeInformationProvider,
       routerDelegate: router.routerDelegate,
+      locale: DevicePreview.locale(context),
+      builder: DevicePreview.appBuilder,
     );
   }
 }

--- a/lib/feature/start_page.dart
+++ b/lib/feature/start_page.dart
@@ -7,8 +7,8 @@ import 'package:parmosys_flutter/utils/strings.dart';
 import 'package:parmosys_flutter/utils/styles.dart';
 import 'package:parmosys_flutter/widgets/spacings.dart';
 
-class SplashScreen extends StatelessWidget {
-  const SplashScreen({super.key});
+class StartPage extends StatelessWidget {
+  const StartPage({super.key});
 
   void _onPressStart(BuildContext context) => context.goNamed(CategoryPage.route);
 
@@ -18,23 +18,27 @@ class SplashScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: darkBackgroundColor,
       body: Padding(
-        padding: homePadding,
+        padding: startPagePadding,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             spacer,
             Image.asset(Assets.png.lancer.path),
             const VerticalSpace(space: 32.0),
-            Text(
-              homeTitle,
-              style: TextStyles.extraBold,
+            FittedBox(
+              child: Text(
+                homeTitle,
+                style: TextStyles.extraBold,
+              ),
             ),
             const VerticalSpace(space: 16.0),
-            Text(
-              homeDescription,
-              style: TextStyles.light.copyWith(fontSize: 16),
+            FittedBox(
+              child: Text(
+                homeDescription,
+                style: TextStyles.light.copyWith(fontSize: 16),
+              ),
             ),
-            const VerticalSpace(space: 80.0),
+            const Spacer(),
             Center(
               child: ElevatedButton(
                 onPressed: () => _onPressStart(context),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,14 @@
+import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parmosys_flutter/feature/home.dart';
 
 void main() {
-  runApp(const ProviderScope(child: Home()));
+  runApp(
+    ProviderScope(
+      child: DevicePreview(
+        builder: (_) => const Home(),
+      ),
+    ),
+  );
 }

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -9,8 +9,8 @@ const cardButtonLightColor = Color(0xff575656);
 const cardButtonDarkColor = Color(0xff353535);
 const additionalHeaderPadding = EdgeInsets.symmetric(horizontal: 24.0);
 
-// Home
-const homePadding = EdgeInsets.symmetric(horizontal: 16.0);
+// Start Page
+const startPagePadding = EdgeInsets.symmetric(horizontal: 16.0);
 const startButtonPadding = EdgeInsets.symmetric(horizontal: 32.0, vertical: 12.0);
 const startButtonColor = Color(0xff6bbd58);
 const startButtonElevation = 6.0;
@@ -22,7 +22,7 @@ const searchTextHeight = 32.0;
 const locationButtonColor = Color(0xffe05353);
 const locationIconSize = 52.0;
 const searchTextRadius = 32.0;
-const lancerSideImageScale = 3.75;
+const lancerSideImageMultiplier = 0.85;
 const collegesImageSize = 92.0;
 const hallsImageSize = 72.0;
 const recreationalImageSize = 100.0;
@@ -32,7 +32,6 @@ const categoryButtonBackgroundHeight = 80.0;
 const categoryButtonBackgroundWidth = 88.0;
 const categoryButtonRadius = 24.0;
 const categoryPageCardRadius = 64.0;
-const lancerSideImagePadding = EdgeInsets.only(top: 80.0);
 
 // Parmosys Drawer
 const logoColor = Color(0xff668b4f);

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
 import 'package:parmosys_flutter/feature/area/area_page.dart';
 import 'package:parmosys_flutter/feature/category/category_page.dart';
-import 'package:parmosys_flutter/feature/splash_screen.dart';
+import 'package:parmosys_flutter/feature/start_page.dart';
 import 'package:parmosys_flutter/utils/strings.dart';
 
 final navigatorKey = GlobalKey<NavigatorState>();
@@ -13,7 +13,7 @@ final router = GoRouter(
     GoRoute(
       path: initialRoute,
       name: initialRoute,
-      builder: (_, __) => const SplashScreen(),
+      builder: (_, __) => const StartPage(),
     ),
     GoRoute(
       path: CategoryPage.route,
@@ -30,7 +30,7 @@ final router = GoRouter(
   ],
   initialLocation: initialRoute,
   debugLogDiagnostics: kDebugMode,
-  errorBuilder: (_, __) => const SplashScreen(),
+  errorBuilder: (_, __) => const StartPage(),
   observers: [routeObserver],
   navigatorKey: navigatorKey,
 );

--- a/lib/widgets/parmosys_scaffold.dart
+++ b/lib/widgets/parmosys_scaffold.dart
@@ -44,29 +44,31 @@ class ParmosysScaffold extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Padding(
-                  padding: isBackButtonShown ? additionalHeaderPadding : EdgeInsets.zero,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        header.first,
-                        style: extraBold,
-                      ),
-                      Row(
-                        children: [
-                          Text(
-                            header[1],
-                            style: extraBold,
-                          ),
-                          const Icon(
-                            Icons.location_on_rounded,
-                            color: locationButtonColor,
-                            size: locationIconSize,
-                          ),
-                        ],
-                      ),
-                    ],
+                FittedBox(
+                  child: Padding(
+                    padding: isBackButtonShown ? additionalHeaderPadding : EdgeInsets.zero,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          header.first,
+                          style: extraBold,
+                        ),
+                        Row(
+                          children: [
+                            Text(
+                              header[1],
+                              style: extraBold,
+                            ),
+                            const Icon(
+                              Icons.location_on_rounded,
+                              color: locationButtonColor,
+                              size: locationIconSize,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 const VerticalSpace(space: 20.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -246,6 +246,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  device_frame:
+    dependency: transitive
+    description:
+      name: device_frame
+      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  device_preview:
+    dependency: "direct main"
+    description:
+      name: device_preview
+      sha256: a694acdd3894b4c7d600f4ee413afc4ff917f76026b97ab06575fe886429ef19
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   fake_async:
     dependency: transitive
     description:
@@ -315,6 +331,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -421,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -525,6 +554,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -621,6 +658,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
+  device_preview: ^1.2.0
   flutter_carousel_widget: ^3.0.1
   flutter_riverpod: ^2.5.1
   go_router: ^14.2.8


### PR DESCRIPTION
- add device preview package
- wrap home with device preview in main
- rename splash screen to start page
- wrap text in start page with fitted box
- set locale and buildee with device preview in home
- update  consts
- wrap header of parmosys scaffold with fitted box
- wrap category button with expanded
- set overflow of label in category button
- use expanded and align instead of container in category page lancer image
- use multiplier for width in category page lancer image instead of scale
- use listview in area page and center widgets