### PR TITLE
chore: appwrite update

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,17 +30,6 @@ jobs:
       - name: Flutter Version
         run: flutter --version
 
-      - name: Create env.dart
-        run: |
-          cat <<EOF > lib/utils/env.dart
-          class Env {
-            static const endpoint = '';
-            static const projectId = '';
-            static const databaseId = '';
-            static const database = '';
-          }
-          EOF
-
       - name: Install Dependencies
         run: flutter pub get
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@
 *.freezed.dart
 **/lib/gen
 
-#env
-lib/utils/env.dart
-
 # Miscellaneous
 *.class
 *.log

--- a/README.md
+++ b/README.md
@@ -2,24 +2,26 @@
 
 ## Steps to run
 1. Update to latest Flutter version
-2. Place `env.dart` in `lib/utils/env.dart`
+2. Setup database:
    <details>
-   <summary>env.dart</summary>
-
-   ```
-   class Env {
-      static const endpoint = '{your appwrite endpoint}';
-      static const projectId = '{your appwrite project id}';
-      static const databaseId = '{appwrite database id where collection is found}';
-      static const database = '{appwrite or firebase}';
-    }
-   ```
+   <summary>Appwrite</summary>
+    
+     1. Copy your Appwrite's Project ID and replace `projectId` in `lib/utils/env.dart`
+     2. Set `database` in `lib/utils/env.dart` to `appwrite` 
 
    </details>
-3. If using Firebase, replace `google-services.json` in `android/app/{google-services.json}` 
-4. Run `flutter pub get`
+
+   <details>
+   <summary>Firebase</summary>
+   
+     1. Add Android to your Firebase project with package name `com.example.parmosys_flutter`
+     2. Download the `google-services.json` and replace in `android/app/{google-services.json}`
+     3. Set `database` in `lib/utils/env.dart` to `firebase`
+   
+   </details>
+3. Run `flutter pub get`
+4. Run `flutter pub run build_runner build --delete-conflicting-outputs`
 5. Run `dart format -l 120 --set-exit-if-changed .`
-6. Run `flutter pub run build_runner build --delete-conflicting-outputs`
 
 ## Features
 - Flutter Carousel Widget

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,7 +8,6 @@ analyzer:
   plugins:
     - custom_lint
   exclude:
-    - "lib/utils/env.dart"
     - "**/*.g.dart"
     - "**/*.freezed.dart"
   errors:

--- a/lib/providers/appwrite_client_provider.dart
+++ b/lib/providers/appwrite_client_provider.dart
@@ -1,11 +1,12 @@
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parmosys_flutter/utils/env.dart';
+import 'package:parmosys_flutter/utils/strings.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'appwrite_client_provider.g.dart';
 
 @riverpod
 Client appwriteClient(Ref ref) => Client()
-  ..setEndpoint(Env.endpoint)
+  ..setEndpoint(appwriteEndpoint)
   ..setProject(Env.projectId);

--- a/lib/utils/env.dart
+++ b/lib/utils/env.dart
@@ -1,0 +1,4 @@
+class Env {
+  static const projectId = '{your appwrite project id}';
+  static const database = '{appwrite or firebase}';
+}

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -1,10 +1,10 @@
-import 'package:parmosys_flutter/utils/env.dart';
-
 const initialRoute = '/';
 const themeModeKey = 'themeMode';
 const viewModeKey = 'viewMode';
 const downloadDirectory = '/storage/emulated/0/Download';
-const parkingSpaceChannel = 'databases.${Env.databaseId}.collections.%s.documents';
+const parkingSpaceChannel = 'databases.$appwriteDatabaseId.collections.%s.documents';
+const appwriteDatabaseId = 'parking_spaces';
+const appwriteEndpoint = 'https://cloud.appwrite.io/v1';
 
 // Home
 const startButtonLabel = 'START';


### PR DESCRIPTION
- remove env in gitignore and analysis options
- remove create env dart step in review workflow
- elaborate steps to run section in readme
- directly set endpoint in appwrite client provider instead of env
- directly set database id in get documents function in parking spaces provider instead of env
- add respective strings
- use future for each instead of wait in get all documents function in parking spaces provider instead of env
- add env in utils