### PR TITLE
chore: followed by

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,10 +27,9 @@ void main() async {
         sharedPreferencesProvider.overrideWithValue(prefs),
       ],
       child: DevicePreview(
-        tools: [
-          ...DevicePreview.defaultTools,
+        tools: DevicePreview.defaultTools.followedBy([
           DevicePreviewScreenshot(onScreenshot: screenshotAsFiles(Directory(downloadDirectory))),
-        ],
+        ]).toList(),
         builder: (_) => const Home(),
       ),
     ),

--- a/lib/providers/parking_spaces_provider.dart
+++ b/lib/providers/parking_spaces_provider.dart
@@ -30,7 +30,9 @@ class ParkingSpaces extends _$ParkingSpaces {
     final client = ref.read(appwriteClientProvider);
     final database = Databases(client);
     final isar = ref.read(isarInstanceProvider);
-    final areas = [...collegesAreas, ...hallsAreas, ...recreationalAreas];
+    final areas = collegesAreas
+      ..followedBy(hallsAreas)
+      ..followedBy(recreationalAreas);
 
     try {
       await Future.forEach(


### PR DESCRIPTION
- use followed by instead of spread operator when setting device preview tools in main
- use followed by instead of spread operator for settings areas when getting all documents in parking spaces provider