### PR TITLE
chore: cleanup

### DIFF
--- a/lib/feature/area/area_carousel.dart
+++ b/lib/feature/area/area_carousel.dart
@@ -22,13 +22,7 @@ class AreaCarousel extends ConsumerStatefulWidget {
 }
 
 class _AreaCarouselState extends ConsumerState<AreaCarousel> {
-  late final ValueNotifier<int> _currentIndexNotifier;
-
-  @override
-  void initState() {
-    _currentIndexNotifier = ValueNotifier(0);
-    super.initState();
-  }
+  late final _currentIndexNotifier = ValueNotifier(0);
 
   @override
   void dispose() {

--- a/lib/feature/category/category_button.dart
+++ b/lib/feature/category/category_button.dart
@@ -41,12 +41,14 @@ class CategoryButton extends StatelessWidget {
               child: Stack(
                 alignment: Alignment.center,
                 children: [
-                  Container(
+                  SizedBox(
                     height: categoryButtonBackgroundHeight,
                     width: categoryButtonBackgroundWidth,
-                    decoration: BoxDecoration(
-                      color: isDarkMode ? cardButtonDarkColor : cardButtonLightColor,
-                      borderRadius: borderRadius,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: isDarkMode ? cardButtonDarkColor : cardButtonLightColor,
+                        borderRadius: borderRadius,
+                      ),
                     ),
                   ),
                   Positioned(

--- a/lib/feature/category/category_page.dart
+++ b/lib/feature/category/category_page.dart
@@ -29,7 +29,7 @@ class CategoryPage extends ConsumerWidget {
           alignment: Alignment.centerRight,
           child: Image.asset(
             Assets.png.lancerSide.path,
-            width: MediaQuery.of(context).size.width * lancerSideImageMultiplier,
+            width: MediaQuery.sizeOf(context).width * lancerSideImageMultiplier,
           ),
         ),
       ),

--- a/lib/feature/parking_space/parking_space_card.dart
+++ b/lib/feature/parking_space/parking_space_card.dart
@@ -48,7 +48,6 @@ class ParkingSpaceCard extends ConsumerWidget {
             SpotList(
               alignment: Alignment.topRight,
               divider: divider,
-              initialSpotCount: leftCount,
               parkingSpaces: parkingSpaces.sublist(leftCount),
             ),
           ],

--- a/lib/feature/parking_space/parking_space_page.dart
+++ b/lib/feature/parking_space/parking_space_page.dart
@@ -97,10 +97,12 @@ class ParkingSpacePage extends ConsumerWidget {
               ),
               decoration: BoxDecoration(color: backgroundColor),
             ),
-            Container(
+            DecoratedBox(
               decoration: decoration,
-              padding: parkingSpaceCardPadding,
-              child: const ParkingSpaceCard(),
+              child: const Padding(
+                padding: parkingSpaceCardPadding,
+                child: ParkingSpaceCard(),
+              ),
             ),
           ],
         ),

--- a/lib/feature/parking_space/spot_list.dart
+++ b/lib/feature/parking_space/spot_list.dart
@@ -13,14 +13,12 @@ class SpotList extends StatelessWidget {
     required this.parkingSpaces,
     required this.divider,
     this.alignment = Alignment.topLeft,
-    this.initialSpotCount,
     super.key,
   });
 
   final List<ParkingSpaceDto> parkingSpaces;
   final Alignment alignment;
   final Widget divider;
-  final int? initialSpotCount;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/feature/start/start_page.dart
+++ b/lib/feature/start/start_page.dart
@@ -25,10 +25,7 @@ class StartPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    const spacer = Spacer();
-
     ref.listen(loadingStateProvider, (previous, next) => _loadingStateListener(context, previous, next));
-
     return Scaffold(
       backgroundColor: darkBackgroundColor,
       body: Padding(
@@ -36,7 +33,7 @@ class StartPage extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            spacer,
+            const Spacer(),
             Image.asset(Assets.png.lancer.path),
             const VerticalSpace(space: 32.0),
             FittedBox(
@@ -52,9 +49,9 @@ class StartPage extends ConsumerWidget {
                 style: TextStyles.light.copyWith(fontSize: 16),
               ),
             ),
-            spacer,
+            const Spacer(),
             const StartButton(),
-            spacer,
+            const Spacer(),
           ],
         ),
       ),


### PR DESCRIPTION
- remove unnecessary const assigning local variable
- remove unused initial spot count parameter in spot list
- use size of for media query width in category page
- use sizedbox and decorated box instead of container in category button
- use decorated box and padding instead of container in parking space page
- initialize current index notifier directly instead of in init state in area carousel